### PR TITLE
AUTOMLALS-159: executor can not use data client

### DIFF
--- a/executor/data/notebooks/executor-automl.ipynb
+++ b/executor/data/notebooks/executor-automl.ipynb
@@ -38,8 +38,7 @@
     "import yaml\n",
     "from sklearn.preprocessing import LabelEncoder\n",
     "\n",
-    "import neural_network.n_network as nn\n",
-    "from hddataclient import DataRepo"
+    "import neural_network.n_network as nn"
    ]
   },
   {
@@ -78,10 +77,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datarepo = DataRepo(\n",
-    "    description=\"Study as Data Repo\",\n",
-    "    volume_name=f\"/home/jovyan/_jobs/{job_name}/\",\n",
-    ")"
+    "features_path = f\"/home/jovyan/_jobs/{job_name}/{features}\"\n",
+    "target_path = f\"/home/jovyan/_jobs/{job_name}/{target}\""
    ]
   },
   {
@@ -91,8 +88,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X_df = datarepo.load_dataset(features)\n",
-    "y_df = datarepo.load_dataset(target)"
+    "X_df = pd.read_json(features_path)\n",
+    "y_df = pd.read_csv(target_path)"
    ]
   },
   {

--- a/executor/data/notebooks/executor-low-code.ipynb
+++ b/executor/data/notebooks/executor-low-code.ipynb
@@ -30,16 +30,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0935d7c8-41ff-4afc-95b5-10a947820ff8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "module = getattr(__import__(\"sklearn\"), \"linear_model\")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "4fe0a3f5-2d84-464f-8dc4-48f1bad6a604",
    "metadata": {},

--- a/executor/data/notebooks/executor-low-code.ipynb
+++ b/executor/data/notebooks/executor-low-code.ipynb
@@ -30,6 +30,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0935d7c8-41ff-4afc-95b5-10a947820ff8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "module = getattr(__import__(\"sklearn\"), \"linear_model\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "4fe0a3f5-2d84-464f-8dc4-48f1bad6a604",
    "metadata": {},

--- a/executor/data/notebooks/executor-low-code.ipynb
+++ b/executor/data/notebooks/executor-low-code.ipynb
@@ -26,8 +26,7 @@
    "source": [
     "import pandas as pd\n",
     "import yaml\n",
-    "from sklearn.preprocessing import LabelEncoder\n",
-    "from hddataclient import DataRepo"
+    "from sklearn.preprocessing import LabelEncoder"
    ]
   },
   {
@@ -66,10 +65,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datarepo = DataRepo(\n",
-    "    description=\"Study as Data Repo\",\n",
-    "    volume_name=f\"/home/jovyan/_jobs/{job_name}/\",\n",
-    ")"
+    "features_path = f\"/home/jovyan/_jobs/{job_name}/{features}\"\n",
+    "target_path = f\"/home/jovyan/_jobs/{job_name}/{target}\""
    ]
   },
   {
@@ -79,8 +76,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X_df = datarepo.load_dataset(features)\n",
-    "y_df = datarepo.load_dataset(target)"
+    "X_df = pd.read_json(features_path)\n",
+    "y_df = pd.read_csv(target_path)"
    ]
   },
   {
@@ -171,7 +168,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/executor/executor/walker/methods.py
+++ b/executor/executor/walker/methods.py
@@ -1,9 +1,7 @@
-from glob import glob
-from pathlib import Path
-from hddataclient import DataRepo
-import os
 import papermill
 import yaml
+from glob import glob
+from pathlib import Path
 
 
 class WalkerMethods:
@@ -87,13 +85,3 @@ class WalkerMethods:
         }
 
         return study_definition
-
-    def _prepare_data(self, job_name, study_definition):
-        datarepo = DataRepo(
-            description="Study as Data Repo",
-            volume_name=f"/home/jovyan/_jobs/{job_name}/",
-        )
-        features_df = datarepo.load_dataset(study_definition["features_source"])
-        target_df = datarepo.load_dataset(study_definition["target_source"])
-        join_id = study_definition["join_id"]
-        return features_df.merge(target_df, left_on=join_id, right_on=join_id)


### PR DESCRIPTION
Jira ticket: [AUTOMLALS-159](https://gohypergiant.atlassian.net/browse/AUTOMLALS-159)

Note: Originally, the end goal of this ticket was to get all executor demo notebooks running. But I encountered a bug in the mono `hyperdrive` repo that I did not see when testing my changes in the original `mlsdk-image-catalog` repo. All demo notebooks should/will run after this bug has been fixed. For reference, this bug has been documented, and will be addressed, here: [AUTOMLALS-180](https://gohypergiant.atlassian.net/browse/AUTOMLALS-180)