### PR TITLE
AUTOMLALS-180: module import bug

### DIFF
--- a/hypertrain/hypertrain/controllers/hyperparameter_study_tuning.py
+++ b/hypertrain/hypertrain/controllers/hyperparameter_study_tuning.py
@@ -397,6 +397,9 @@ Best Trial Hyperparameters: {self.optuna_study.best_trial.params}
         idx1 = clf_name.rfind(".")
         module_name = clf_name[sklearn_string_length:idx1]
         function_name = clf_name[idx1 + 1 :]
+        import ipdb
+
+        ipdb.set_trace()
         module = getattr(__import__("sklearn"), module_name)
 
         if is_model:

--- a/hypertrain/hypertrain/controllers/hyperparameter_study_tuning.py
+++ b/hypertrain/hypertrain/controllers/hyperparameter_study_tuning.py
@@ -428,7 +428,7 @@ Best Trial Hyperparameters: {self.optuna_study.best_trial.params}
         xgboost_string_length = len("xgboost.")
 
         if clf_name.count(".") == 1:
-            module = __import__("xgboost")
+            module = importlib.import_module("xgboost")
             function_name = clf_name[xgboost_string_length:]
         else:
             idx1 = clf_name.rfind(".")

--- a/hypertrain/hypertrain/controllers/hyperparameter_study_tuning.py
+++ b/hypertrain/hypertrain/controllers/hyperparameter_study_tuning.py
@@ -397,7 +397,7 @@ Best Trial Hyperparameters: {self.optuna_study.best_trial.params}
         sklearn_string_length = len("sklearn.")
         idx1 = clf_name.rfind(".")
         module_name = clf_name[sklearn_string_length:idx1]
-        sklearn_module_name = "sklearn" + "." + module_name
+        sklearn_module_name = "sklearn." + module_name
         function_name = clf_name[idx1 + 1 :]
         module = importlib.import_module(sklearn_module_name)
 
@@ -433,7 +433,7 @@ Best Trial Hyperparameters: {self.optuna_study.best_trial.params}
         else:
             idx1 = clf_name.rfind(".")
             module_name = clf_name[xgboost_string_length:idx1]
-            xgboost_module_name = "xgboost" + "." + module_name
+            xgboost_module_name = "xgboost." + module_name
             function_name = clf_name[idx1 + 1 :]
             module = importlib.import_module(xgboost_module_name)
 

--- a/hypertrain/hypertrain/controllers/hyperparameter_study_tuning.py
+++ b/hypertrain/hypertrain/controllers/hyperparameter_study_tuning.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import importlib
 from uuid import uuid4
 
 import numpy as np
@@ -396,11 +397,9 @@ Best Trial Hyperparameters: {self.optuna_study.best_trial.params}
         sklearn_string_length = len("sklearn.")
         idx1 = clf_name.rfind(".")
         module_name = clf_name[sklearn_string_length:idx1]
+        sklearn_module_name = "sklearn" + "." + module_name
         function_name = clf_name[idx1 + 1 :]
-        import ipdb
-
-        ipdb.set_trace()
-        module = getattr(__import__("sklearn"), module_name)
+        module = importlib.import_module(sklearn_module_name)
 
         if is_model:
             return getattr(module, function_name)(**hyperparams_for_current_model)

--- a/hypertrain/hypertrain/controllers/hyperparameter_study_tuning.py
+++ b/hypertrain/hypertrain/controllers/hyperparameter_study_tuning.py
@@ -433,8 +433,9 @@ Best Trial Hyperparameters: {self.optuna_study.best_trial.params}
         else:
             idx1 = clf_name.rfind(".")
             module_name = clf_name[xgboost_string_length:idx1]
+            xgboost_module_name = "xgboost" + "." + module_name
             function_name = clf_name[idx1 + 1 :]
-            module = getattr(__import__("xgboost"), module_name)
+            module = importlib.import_module(xgboost_module_name)
 
         if is_model:
             return getattr(module, function_name)(**hyperparams_for_current_model)


### PR DESCRIPTION
Jira ticket: [AUTOMLALS-180](https://gohypergiant.atlassian.net/browse/AUTOMLALS-180)

Fixed module importing in the `_instantiate_sklearn_object` and `_instantiate_xgboost_object` functions.

Also, as part of the fix, and as recommended by the python documentation [here](https://docs.python.org/3/library/functions.html#import__), we've switched from using `__import__` to `importlib.import_module()`. Here is the relevant line:

_Direct use of `__import__()`(https://docs.python.org/3/library/functions.html#import__) is also discouraged in favor of [importlib.import_module()](https://docs.python.org/3/library/importlib.html#importlib.import_module).