### PR TITLE
workflow: hypergiant-jupyter -> hyperdrive-jupyter

### DIFF
--- a/.github/workflows/build-jupyter-workflow.yml
+++ b/.github/workflows/build-jupyter-workflow.yml
@@ -82,7 +82,7 @@ jobs:
         id: meta
         uses: crazy-max/ghaction-docker-meta@v2
         with:
-          images: ghcr.io/${{ github.repository_owner }}/hypergiant-jupyter
+          images: ghcr.io/${{ github.repository_owner }}/hyperdrive-jupyter
           labels: |
             maintainer=@gohypergiant
             org.opencontainers.image.title=Hyperdrive Notebooks Base Image


### PR DESCRIPTION
For ghcr, `hypergiant-jupyter` was confirmed to be redundant. Changed the `build-jupyter-workflow.yml` to point to `hyperdrive-jupyter` instead.