### PR TITLE
Add  `jupyter list` ec2 implementation

### DIFF
--- a/hyper/client/aws/ec2.go
+++ b/hyper/client/aws/ec2.go
@@ -1,0 +1,83 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/docker/distribution/uuid"
+
+	HyperConfig "github.com/gohypergiant/hyperdrive/hyper/services/config"
+)
+
+const HYPERDRIVE_TYPE_TAG string = "hyperdrive-type"
+const HYPERDRIVE_NAME_TAG string = "hyperdrive-name"
+
+type EC2DescribeInstancesAPI interface {
+	DescribeInstances(ctx context.Context,
+		params *ec2.DescribeInstancesInput,
+		optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+}
+
+func GetInstances(c context.Context, api EC2DescribeInstancesAPI, input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+	return api.DescribeInstances(c, input)
+}
+func GetEC2Client(remoteCfg HyperConfig.EC2RemoteConfiguration) *ec2.Client {
+
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithSharedConfigProfile(remoteCfg.Profile))
+	cfg.Region = remoteCfg.Region
+	if remoteCfg.AccessKey != "" && remoteCfg.Secret != "" {
+		cfg.Credentials = aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(remoteCfg.AccessKey, remoteCfg.Secret, uuid.Generate().String()))
+	}
+	if err != nil {
+		panic("configuration error, " + err.Error())
+	}
+
+	return ec2.NewFromConfig(cfg)
+
+}
+func ListServers(remoteCfg HyperConfig.EC2RemoteConfiguration) {
+
+	client := GetEC2Client(remoteCfg)
+	input := &ec2.DescribeInstancesInput{}
+
+	result, err := GetInstances(context.TODO(), client, input)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+		return
+	}
+
+	for _, r := range result.Reservations {
+		fmt.Println("Instance IDs:")
+		for _, i := range r.Instances {
+			if IsHyperdriveInstance(i) {
+				fmt.Println("   " + GetHyperName(i))
+			}
+		}
+
+		fmt.Println("")
+	}
+
+}
+func IsHyperdriveInstance(i types.Instance) bool {
+	for _, t := range i.Tags {
+		if *t.Key == HYPERDRIVE_TYPE_TAG {
+			return true
+		}
+	}
+	return false
+}
+func GetHyperName(i types.Instance) string {
+	for _, t := range i.Tags {
+		if *t.Key == HYPERDRIVE_NAME_TAG {
+			return *t.Value
+		}
+	}
+	return ""
+}

--- a/hyper/services/notebook/remote.go
+++ b/hyper/services/notebook/remote.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gohypergiant/hyperdrive/hyper/client/aws"
 	"github.com/gohypergiant/hyperdrive/hyper/client/firefly"
 	"github.com/gohypergiant/hyperdrive/hyper/client/manifest"
 	"github.com/gohypergiant/hyperdrive/hyper/services/config"
@@ -39,6 +40,8 @@ func (s RemoteNotebookService) List() {
 			fmt.Println(fmt.Sprintf("%s:", name))
 			fmt.Println("URL: ", info.URL)
 		}
+	}else if s.RemoteConfiguration.Type == config.EC2 {
+		aws.ListServers(s.RemoteConfiguration.EC2Configuration);
 	} else {
 		fmt.Println("Not Implemented")
 	}


### PR DESCRIPTION
Assuming you have a remote configured and the associated account has an ec2 instance with two tags "hyperdrive-type" (values being "train" or "deploy") and "hyperdrive-name" (name being whatever is in they hyperpack manifest)