### PR TITLE
Add CLI function to Stop EC2 Instance server

### DIFF
--- a/hyper/client/aws/ec2.go
+++ b/hyper/client/aws/ec2.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -31,6 +32,11 @@ type EC2CreateInstanceAPI interface {
 		params *ec2.RunInstancesInput,
 		optFns ...func(*ec2.Options)) (*ec2.RunInstancesOutput, error)
 }
+type TerminateInstancesAPI interface {
+	TerminateInstances(ctx context.Context,
+		params *ec2.TerminateInstancesInput,
+		optFns ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error)
+}
 type DescribeVpcsAPI interface {
 	DescribeVpcs(ctx context.Context,
 		params *ec2.DescribeVpcsInput,
@@ -40,6 +46,11 @@ type CreateVpcAPI interface {
 	CreateVpc(ctx context.Context,
 		params *ec2.CreateVpcInput,
 		optFns ...func(*ec2.Options)) (*ec2.CreateVpcOutput, error)
+}
+type DeleteVpcAPI interface {
+	DeleteVpc(ctx context.Context,
+		params *ec2.DeleteVpcInput,
+		optFns ...func(*ec2.Options)) (*ec2.DeleteVpcOutput, error)
 }
 type DescribeSubnetsAPI interface {
 	DescribeSubnets(ctx context.Context,
@@ -51,30 +62,65 @@ type CreateSubnetAPI interface {
 		params *ec2.CreateSubnetInput,
 		optFns ...func(*ec2.Options)) (*ec2.CreateSubnetOutput, error)
 }
+type DeleteSubnetAPI interface {
+	DeleteSubnet(ctx context.Context,
+		params *ec2.DeleteSubnetInput,
+		optFns ...func(*ec2.Options)) (*ec2.DeleteSubnetOutput, error)
+}
 type ModifySubnetAttributeAPI interface {
 	ModifySubnetAttribute(ctx context.Context,
 		params *ec2.ModifySubnetAttributeInput,
 		optFns ...func(*ec2.Options)) (*ec2.ModifySubnetAttributeOutput, error)
+}
+type DescribeInternetGatewaysAPI interface {
+	DescribeInternetGateways(ctx context.Context,
+		params *ec2.DescribeInternetGatewaysInput,
+		optFns ...func(*ec2.Options)) (*ec2.DescribeInternetGatewaysOutput, error)
 }
 type CreateInternetGatewayAPI interface {
 	CreateInternetGateway(ctx context.Context,
 		params *ec2.CreateInternetGatewayInput,
 		optFns ...func(*ec2.Options)) (*ec2.CreateInternetGatewayOutput, error)
 }
+type DeleteInternetGatewayAPI interface {
+	DeleteInternetGateway(ctx context.Context,
+		params *ec2.DeleteInternetGatewayInput,
+		optFns ...func(*ec2.Options)) (*ec2.DeleteInternetGatewayOutput, error)
+}
 type AttachInternetGatewayAPI interface {
 	AttachInternetGateway(ctx context.Context,
 		params *ec2.AttachInternetGatewayInput,
 		optFns ...func(*ec2.Options)) (*ec2.AttachInternetGatewayOutput, error)
+}
+type DetachInternetGatewayAPI interface {
+	DetachInternetGateway(ctx context.Context,
+		params *ec2.DetachInternetGatewayInput,
+		optFns ...func(*ec2.Options)) (*ec2.DetachInternetGatewayOutput, error)
+}
+type DescribeRouteTablesAPI interface {
+	DescribeRouteTables(ctx context.Context,
+		params *ec2.DescribeRouteTablesInput,
+		optFns ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error)
 }
 type CreateRouteTableAPI interface {
 	CreateRouteTable(ctx context.Context,
 		params *ec2.CreateRouteTableInput,
 		optFns ...func(*ec2.Options)) (*ec2.CreateRouteTableOutput, error)
 }
+type DeleteRouteTableAPI interface {
+	DeleteRouteTable(ctx context.Context,
+		params *ec2.DeleteRouteTableInput,
+		optFns ...func(*ec2.Options)) (*ec2.DeleteRouteTableOutput, error)
+}
 type AssociateRouteTableAPI interface {
 	AssociateRouteTable(ctx context.Context,
 		params *ec2.AssociateRouteTableInput,
 		optFns ...func(*ec2.Options)) (*ec2.AssociateRouteTableOutput, error)
+}
+type DisassociateRouteTableAPI interface {
+	DisassociateRouteTable(ctx context.Context,
+		params *ec2.DisassociateRouteTableInput,
+		optFns ...func(*ec2.Options)) (*ec2.DisassociateRouteTableOutput, error)
 }
 type CreateRouteAPI interface {
 	CreateRoute(ctx context.Context,
@@ -91,6 +137,11 @@ type CreateSecurityGroupAPI interface {
 		params *ec2.CreateSecurityGroupInput,
 		optFns ...func(*ec2.Options)) (*ec2.CreateSecurityGroupOutput, error)
 }
+type DeleteSecurityGroupAPI interface {
+	DeleteSecurityGroup(ctx context.Context,
+		params *ec2.DeleteSecurityGroupInput,
+		optFns ...func(*ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error)
+}
 type AddSecurityGroupPermissionsAPI interface {
 	AuthorizeSecurityGroupIngress(ctx context.Context,
 		params *ec2.AuthorizeSecurityGroupIngressInput,
@@ -105,6 +156,11 @@ type CreateKeyPairAPI interface {
 	CreateKeyPair(ctx context.Context,
 		params *ec2.CreateKeyPairInput,
 		optFns ...func(*ec2.Options)) (*ec2.CreateKeyPairOutput, error)
+}
+type DeleteKeyPairAPI interface {
+	DeleteKeyPair(ctx context.Context,
+		params *ec2.DeleteKeyPairInput,
+		optFns ...func(*ec2.Options)) (*ec2.DeleteKeyPairOutput, error)
 }
 
 func GetInstances(c context.Context, api EC2DescribeInstancesAPI, input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
@@ -167,11 +223,17 @@ func GetHyperName(i types.Instance) string {
 func MakeInstance(c context.Context, api EC2CreateInstanceAPI, input *ec2.RunInstancesInput) (*ec2.RunInstancesOutput, error) {
 	return api.RunInstances(c, input)
 }
+func DeleteInstances(c context.Context, api TerminateInstancesAPI, input *ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error) {
+	return api.TerminateInstances(c, input)
+}
 func GetVpcs(c context.Context, api DescribeVpcsAPI, input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
 	return api.DescribeVpcs(c, input)
 }
 func MakeVpc(c context.Context, api CreateVpcAPI, input *ec2.CreateVpcInput) (*ec2.CreateVpcOutput, error) {
 	return api.CreateVpc(c, input)
+}
+func DeleteVpc(c context.Context, api DeleteVpcAPI, input *ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error) {
+	return api.DeleteVpc(c, input)
 }
 func GetSubnets(c context.Context, api DescribeSubnetsAPI, input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
 	return api.DescribeSubnets(c, input)
@@ -179,20 +241,41 @@ func GetSubnets(c context.Context, api DescribeSubnetsAPI, input *ec2.DescribeSu
 func MakeSubnet(c context.Context, api CreateSubnetAPI, input *ec2.CreateSubnetInput) (*ec2.CreateSubnetOutput, error) {
 	return api.CreateSubnet(c, input)
 }
+func DeleteSubnet(c context.Context, api DeleteSubnetAPI, input *ec2.DeleteSubnetInput) (*ec2.DeleteSubnetOutput, error) {
+	return api.DeleteSubnet(c, input)
+}
 func ChangeSubnet(c context.Context, api ModifySubnetAttributeAPI, input *ec2.ModifySubnetAttributeInput) (*ec2.ModifySubnetAttributeOutput, error) {
 	return api.ModifySubnetAttribute(c, input)
+}
+func GetInternetGateways(c context.Context, api DescribeInternetGatewaysAPI, input *ec2.DescribeInternetGatewaysInput) (*ec2.DescribeInternetGatewaysOutput, error) {
+	return api.DescribeInternetGateways(c, input)
 }
 func MakeInternetGateway(c context.Context, api CreateInternetGatewayAPI, input *ec2.CreateInternetGatewayInput) (*ec2.CreateInternetGatewayOutput, error) {
 	return api.CreateInternetGateway(c, input)
 }
+func DeleteInternetGateway(c context.Context, api DeleteInternetGatewayAPI, input *ec2.DeleteInternetGatewayInput) (*ec2.DeleteInternetGatewayOutput, error) {
+	return api.DeleteInternetGateway(c, input)
+}
 func AttachInternetGateway(c context.Context, api AttachInternetGatewayAPI, input *ec2.AttachInternetGatewayInput) (*ec2.AttachInternetGatewayOutput, error) {
 	return api.AttachInternetGateway(c, input)
+}
+func DetachInternetGateway(c context.Context, api DetachInternetGatewayAPI, input *ec2.DetachInternetGatewayInput) (*ec2.DetachInternetGatewayOutput, error) {
+	return api.DetachInternetGateway(c, input)
+}
+func DescribeRouteTables(c context.Context, api DescribeRouteTablesAPI, input *ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error) {
+	return api.DescribeRouteTables(c, input)
 }
 func MakeRouteTable(c context.Context, api CreateRouteTableAPI, input *ec2.CreateRouteTableInput) (*ec2.CreateRouteTableOutput, error) {
 	return api.CreateRouteTable(c, input)
 }
+func DeleteRouteTable(c context.Context, api DeleteRouteTableAPI, input *ec2.DeleteRouteTableInput) (*ec2.DeleteRouteTableOutput, error) {
+	return api.DeleteRouteTable(c, input)
+}
 func AddRouteTable(c context.Context, api AssociateRouteTableAPI, input *ec2.AssociateRouteTableInput) (*ec2.AssociateRouteTableOutput, error) {
 	return api.AssociateRouteTable(c, input)
+}
+func DisassociateRouteTable(c context.Context, api DisassociateRouteTableAPI, input *ec2.DisassociateRouteTableInput) (*ec2.DisassociateRouteTableOutput, error) {
+	return api.DisassociateRouteTable(c, input)
 }
 func AddRoute(c context.Context, api CreateRouteAPI, input *ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error) {
 	return api.CreateRoute(c, input)
@@ -203,6 +286,9 @@ func GetSecurityGroups(c context.Context, api DescribeSecurityGroupsAPI, input *
 func MakeSecurityGroup(c context.Context, api CreateSecurityGroupAPI, input *ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error) {
 	return api.CreateSecurityGroup(c, input)
 }
+func DeleteSecurityGroup(c context.Context, api DeleteSecurityGroupAPI, input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+	return api.DeleteSecurityGroup(c, input)
+}
 func MakeSecurityGroupPermissions(c context.Context, api AddSecurityGroupPermissionsAPI, input *ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
 	return api.AuthorizeSecurityGroupIngress(c, input)
 }
@@ -211,6 +297,9 @@ func GetKeyPairs(c context.Context, api DescribeKeyPairsAPI, input *ec2.Describe
 }
 func MakeKeyPair(c context.Context, api CreateKeyPairAPI, input *ec2.CreateKeyPairInput) (*ec2.CreateKeyPairOutput, error) {
 	return api.CreateKeyPair(c, input)
+}
+func DeleteKeyPair(c context.Context, api DeleteKeyPairAPI, input *ec2.DeleteKeyPairInput) (*ec2.DeleteKeyPairOutput, error) {
+	return api.DeleteKeyPair(c, input)
 }
 func CreateInternetGateway(client *ec2.Client, projectName string) string {
 	tagSpecification := []types.TagSpecification{
@@ -668,4 +757,282 @@ func StartServer(manifestPath string, remoteCfg HyperConfig.EC2RemoteConfigurati
 	}
 	fmt.Print("EC2 instance provisioned. You can access via ssh by running:")
 	fmt.Print("ssh -i " + keyName + ".pem ec2-user@" + *result.Instances[0].PublicIpAddress)
+}
+func GetRouteTableID(r *ec2.DescribeRouteTablesOutput, projectName string) string {
+
+	for _, r := range r.RouteTables {
+		for _, t := range r.Tags {
+			if *t.Key == HYPERDRIVE_NAME_TAG && *t.Value == projectName {
+				return *r.RouteTableId
+			}
+		}
+	}
+	return ""
+}
+func GetAssociationID(r *ec2.DescribeRouteTablesOutput, subnetID string) string {
+	for _, rt := range r.RouteTables {
+		for _, a := range rt.Associations {
+			if a.SubnetId == &subnetID {
+				return *a.RouteTableAssociationId
+			}
+		}
+	}
+	return ""
+}
+func GetInternetGatewayID(r *ec2.DescribeInternetGatewaysOutput, projectName string) string {
+	for _, i := range r.InternetGateways {
+		for _, t := range i.Tags {
+			if *t.Key == HYPERDRIVE_NAME_TAG && *t.Value == projectName {
+				return *i.InternetGatewayId
+			}
+		}
+	}
+	return ""
+}
+func StopServer(manifestPath string, remoteCfg HyperConfig.EC2RemoteConfiguration) {
+	projectName := manifest.GetProjectName(manifestPath)
+	if projectName == "" {
+		fmt.Println("ProjectNameNotFound: please specify a project_name on the manifest (", manifestPath, ")")
+		return
+	}
+
+	client := GetEC2Client(remoteCfg)
+
+	vpcDescribeInput := &ec2.DescribeVpcsInput{}
+	vpcDescribeResult, err := GetVpcs(context.TODO(), client, vpcDescribeInput)
+	if err != nil {
+		panic("error when fetching VPCs, " + err.Error())
+	}
+
+	vpcID := GetVpcId(vpcDescribeResult, projectName)
+
+	if vpcID == "" {
+		fmt.Println("No VPC associated with this project found")
+		return
+	}
+
+	ec2DescribeInput := &ec2.DescribeInstancesInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []string{vpcID},
+			},
+			{
+				Name:   aws.String("instance-state-code"),
+				Values: []string{"16"},
+			},
+		},
+	}
+
+	ec2DescribeResult, err := GetInstances(context.TODO(), client, ec2DescribeInput)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+		return
+	}
+
+	for _, r := range ec2DescribeResult.Reservations {
+		for _, i := range r.Instances {
+			if IsHyperdriveInstance(i) {
+				instanceTerminateInput := &ec2.TerminateInstancesInput{
+					InstanceIds: []string{*i.InstanceId},
+				}
+
+				_, err = DeleteInstances(context.TODO(), client, instanceTerminateInput)
+				if err != nil {
+					panic("error deleting Instances: " + err.Error())
+				}
+			}
+
+			instanceStatusWaiter := ec2.NewInstanceTerminatedWaiter(client)
+			instanceStatusWaitInput := &ec2.DescribeInstancesInput{
+				Filters: []types.Filter{
+					{
+						Name:   aws.String("instance-id"),
+						Values: []string{*i.InstanceId},
+					},
+				},
+			}
+			_, err := instanceStatusWaiter.WaitForOutput(context.TODO(), instanceStatusWaitInput, time.Duration(240*time.Second))
+			if err != nil {
+				panic("error waiting to delete Instance: " + err.Error())
+			}
+
+			fmt.Println("Instance deleted:", *i.InstanceId)
+		}
+	}
+
+	keyPairDescribeInput := &ec2.DescribeKeyPairsInput{
+		IncludePublicKey: aws.Bool(true),
+	}
+
+	keyPairDescribeResult, err := GetKeyPairs(context.TODO(), client, keyPairDescribeInput)
+	if err != nil {
+		panic("error fetching Key Pairs: " + err.Error())
+	}
+	keyName := getKeyPairName(keyPairDescribeResult, projectName)
+
+	if keyName != "" {
+		keyPairDeleteInput := &ec2.DeleteKeyPairInput{
+			KeyName: aws.String(keyName),
+		}
+
+		_, err = DeleteKeyPair(context.TODO(), client, keyPairDeleteInput)
+		if err != nil {
+			panic("error deleting Key Pair: " + err.Error())
+		}
+		fmt.Println("Key Pair deleted:", keyName)
+
+		keyPath := path.Join(os.Getenv("HOME"), fmt.Sprintf("%s.pem", keyName))
+		_, err := os.Stat(keyPath)
+		if err == nil {
+			err = os.Remove(keyPath)
+			if err != nil {
+				panic("error deleting local pem file: " + err.Error())
+			}
+		}
+	}
+
+	securityGroupDescribeInput := &ec2.DescribeSecurityGroupsInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []string{vpcID},
+			},
+		},
+	}
+	securityGroupDescribeResult, err := GetSecurityGroups(context.TODO(), client, securityGroupDescribeInput)
+	if err != nil {
+		panic("error fetching Security Groups," + err.Error())
+	}
+
+	securityGroupID := GetSecurityGroupId(securityGroupDescribeResult, projectName)
+
+	if securityGroupID != "" {
+		securityGroupDeleteInput := &ec2.DeleteSecurityGroupInput{
+			GroupId: aws.String(securityGroupID),
+		}
+
+		_, err = DeleteSecurityGroup(context.TODO(), client, securityGroupDeleteInput)
+		if err != nil {
+			panic("error deleting Security Group," + err.Error())
+		}
+		fmt.Println("Security Group deleted:", securityGroupID)
+	}
+
+	subnetDescribeInput := &ec2.DescribeSubnetsInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []string{vpcID},
+			},
+		},
+	}
+	subnetDescribeResult, err := GetSubnets(context.TODO(), client, subnetDescribeInput)
+	if err != nil {
+		panic("error fetching Subnets," + err.Error())
+	}
+
+	subnetID := GetSubnetID(subnetDescribeResult, projectName)
+
+	if subnetID != "" {
+		routeTableDescribeInput := &ec2.DescribeRouteTablesInput{
+			Filters: []types.Filter{
+				{
+					Name:   aws.String("vpc-id"),
+					Values: []string{vpcID},
+				},
+				{
+					Name:   aws.String("association.subnet-id"),
+					Values: []string{subnetID},
+				},
+			},
+		}
+
+		routeTableDescribeOutput, err := DescribeRouteTables(context.TODO(), client, routeTableDescribeInput)
+		if err != nil {
+			panic("error fetching Route Tables," + err.Error())
+		}
+
+		for _, rt := range routeTableDescribeOutput.RouteTables {
+			routeTableID := *rt.RouteTableId
+
+			for _, a := range rt.Associations {
+				associationID := *a.RouteTableAssociationId
+
+				routeTableDisassociateInput := &ec2.DisassociateRouteTableInput{
+					AssociationId: aws.String(associationID),
+				}
+				_, err = DisassociateRouteTable(context.TODO(), client, routeTableDisassociateInput)
+				if err != nil {
+					panic("error disassociationg Route Table," + err.Error())
+				}
+			}
+			routeTableDeleteInput := &ec2.DeleteRouteTableInput{
+				RouteTableId: aws.String(routeTableID),
+			}
+			_, err = DeleteRouteTable(context.TODO(), client, routeTableDeleteInput)
+			if err != nil {
+				panic("error deleting Route Table," + err.Error())
+			}
+			fmt.Println("Route Table deleted:", routeTableID)
+		}
+	}
+
+	internetGatewayDescribeInput := &ec2.DescribeInternetGatewaysInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("attachment.vpc-id"),
+				Values: []string{vpcID},
+			},
+		},
+	}
+	internetGatewayDescribeResult, err := GetInternetGateways(context.TODO(), client, internetGatewayDescribeInput)
+	if err != nil {
+		panic("error fetching Internet Gateways," + err.Error())
+	}
+	internetGatewayID := GetInternetGatewayID(internetGatewayDescribeResult, projectName)
+
+	if internetGatewayID != "" {
+		internetGatewayDetachInput := &ec2.DetachInternetGatewayInput{
+			InternetGatewayId: aws.String(internetGatewayID),
+			VpcId:             aws.String(vpcID),
+		}
+		_, err = DetachInternetGateway(context.TODO(), client, internetGatewayDetachInput)
+		if err != nil {
+			panic("error detaching Internet Gateway," + err.Error())
+		}
+
+		internetGatewayDeleteInput := &ec2.DeleteInternetGatewayInput{
+			InternetGatewayId: aws.String(internetGatewayID),
+		}
+
+		_, err = DeleteInternetGateway(context.TODO(), client, internetGatewayDeleteInput)
+		if err != nil {
+			panic("error deleting Internet Gateway," + err.Error())
+		}
+		fmt.Println("Internet Gateway deleted:", internetGatewayID)
+	}
+
+	if subnetID != "" {
+		subnetDeleteInput := &ec2.DeleteSubnetInput{
+			SubnetId: aws.String(subnetID),
+		}
+		_, err = DeleteSubnet(context.TODO(), client, subnetDeleteInput)
+		if err != nil {
+			panic("error deleting Subnet," + err.Error())
+		}
+		fmt.Println("Subnet deleted:", subnetID)
+	}
+
+	if vpcID != "" {
+		vpcDeleteInput := &ec2.DeleteVpcInput{
+			VpcId: aws.String(vpcID),
+		}
+		_, err = DeleteVpc(context.TODO(), client, vpcDeleteInput)
+		if err != nil {
+			panic("error deleting VPC," + err.Error())
+		}
+		fmt.Println("VPC deleted:", vpcID)
+	}
 }

--- a/hyper/services/notebook/remote.go
+++ b/hyper/services/notebook/remote.go
@@ -52,6 +52,8 @@ func (s RemoteNotebookService) Stop(identifier string) {
 	name := GetNotebookName(s.ManifestPath)
 	if s.RemoteConfiguration.Type == config.Firefly {
 		firefly.StopServer(s.RemoteConfiguration.FireflyConfiguration, name)
+	} else if s.RemoteConfiguration.Type == config.EC2 {
+		aws.StopServer(s.ManifestPath, s.RemoteConfiguration.EC2Configuration)
 	} else {
 		fmt.Println("Not Implemented")
 	}


### PR DESCRIPTION
[MLSDK-135](https://gohypergiant.atlassian.net/browse/MLSDK-135)

Enables the command `hyper jupyter stop --remote <EC2_PROFILE>` to stop an EC2 instance server and delete all the components created in the AWS account that were generated when running  `hyper jupyter --remote <EC2_PROFILE>`