### PR TITLE
env vars s/b UPPERCASE

### DIFF
--- a/hyper/client/cli/docker.go
+++ b/hyper/client/cli/docker.go
@@ -181,8 +181,8 @@ RUN unzip ./study.hyperpackage.zip -d /hyperpackage
 
 FROM ghcr.io/gohypergiant/gohypergiant/mlsdk-fast-app:stable
 COPY --from=builder /hyperpackage /hyperpackage
-ENV fastkey=%s
-RUN echo "*** Fast App API key is: $fastkey ***"
+ENV FASTKEY=%s
+RUN echo "*** Fast App API key is: $FASTKEY ***"
 `, fastAppApiKey)
 	}
 


### PR DESCRIPTION
fastkey -> FASTKEY, because env vars should be UPPERCASE.