### PR TITLE
MLSDK-363: hyperpackage | write hyperpack to s3

### DIFF
--- a/fastapp/fastapp/services/hyperpackage.py
+++ b/fastapp/fastapp/services/hyperpackage.py
@@ -12,15 +12,15 @@ hyperpackage_s3_path = "/" + hyperpackage_s3_file
 
 if path.exists(hyperpackage_s3_path):
     session = boto3.Session()
-    client = session.client('s3')    
+    client = session.client("s3")
 
-    with open(hyperpackage_s3_path, 'r') as f:
-        lines = f.read().splitlines() 
+    with open(hyperpackage_s3_path, "r") as f:
+        lines = f.read().splitlines()
         bucket = lines[0]
         s3_hyperpack_path = lines[1]
         client.download_file(bucket, s3_hyperpack_path, "hyperpack.zip")
 
-        with zipfile.ZipFile("hyperpack.zip","r") as zip_file:
+        with zipfile.ZipFile("hyperpack.zip", "r") as zip_file:
             zip_file.extractall(hyperpackage_path)
 
 for item in listdir(hyperpackage_path):

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -34,6 +34,7 @@ def write_hyperpack_to_s3(
 ):
     if hyperpack_path == "":
         raise ValueError("Please pass in the path to your hyperpack zip file.")
+
     if (
         access_key_id in [None, ""]
         or secret_access_key in [None, ""]
@@ -42,8 +43,10 @@ def write_hyperpack_to_s3(
         raise ValueError(
             "Please pass in the following AWS S3 credentials: access_key_id, secret_access_key, and session_token."
         )
+
     if s3_bucket_path in [None, ""]:
         raise ValueError("Please pass in a S3 bucket path.")
+
     print("ciao mondo!")
 
 

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -25,7 +25,9 @@ def generate_folder_name(
     return folder_name
 
 
-def write_hyperpack_to_s3():
+def write_hyperpack_to_s3(
+    access_key_id="", secret_access_key="", session_token="", s3_bucket_path=""
+):
     print("ciao mondo!")
 
 

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -26,8 +26,14 @@ def generate_folder_name(
 
 
 def write_hyperpack_to_s3(
-    access_key_id=None, secret_access_key=None, session_token=None, s3_bucket_path=None
+    hyperpack_path="",
+    access_key_id=None,
+    secret_access_key=None,
+    session_token=None,
+    s3_bucket_path=None,
 ):
+    if hyperpack_path == "":
+        raise ValueError("Please pass in the path to your hyperpack zip file.")
     if (
         access_key_id in [None, ""]
         or secret_access_key in [None, ""]

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -36,7 +36,9 @@ def write_hyperpack_to_s3(
     s3_bucket=None,
 ):
     if hyperpack_file == "":
-        raise ValueError("Please pass in the name or path to your hyperpack zip file.")
+        raise ValueError(
+            "Please pass in the name of, or path to, your hyperpack zip file."
+        )
     elif not os.path.isfile(hyperpack_file):
         raise FileNotFoundError("No file could be found at {}".format(hyperpack_file))
     elif not zipfile.is_zipfile(hyperpack_file):
@@ -66,10 +68,10 @@ def write_hyperpack_to_s3(
     try:
         s3.meta.client.upload_file(hyperpack_file, s3_bucket, s3_object_key)
     except Exception as exp:
-        print("exp: ", exp)
+        print("Error occurred while uploading the hyperpack: ", exp)
         raise
 
-    print("ciao mondo!")
+    print("Hyperpack {} written to the {} S3 bucket".format(s3_object_key, s3_bucket))
 
 
 def write_json(dictionary, json_file_path):

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 import yaml
 import zipfile
@@ -35,8 +36,11 @@ def write_hyperpack_to_s3(
 ):
     if hyperpack_path == "":
         raise ValueError("Please pass in the path to your hyperpack zip file.")
+    elif not os.path.isfile(hyperpack_path):
+        raise FileNotFoundError("No file could be found at {}".format(hyperpack_path))
     elif not zipfile.is_zipfile(hyperpack_path):
-        raise TypeError("Invalid zip file.")
+        raise TypeError("The file {} is an invalid zip file.".format(hyperpack_path))
+
     if (
         access_key_id in [None, ""]
         or secret_access_key in [None, ""]

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -26,8 +26,18 @@ def generate_folder_name(
 
 
 def write_hyperpack_to_s3(
-    access_key_id="", secret_access_key="", session_token="", s3_bucket_path=""
+    access_key_id=None, secret_access_key=None, session_token=None, s3_bucket_path=None
 ):
+    if (
+        access_key_id in [None, ""]
+        or secret_access_key in [None, ""]
+        or session_token in [None, ""]
+    ):
+        raise ValueError(
+            "Please pass in the following AWS S3 credentials: access_key_id, secret_access_key, and session_token."
+        )
+    if s3_bucket_path in [None, ""]:
+        raise ValueError("Please pass in a S3 bucket path.")
     print("ciao mondo!")
 
 

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -72,7 +72,7 @@ def write_hyperpack_to_s3(
         raise
 
     print(
-        "*** COMPLETE: The {} hyperpack was written to the {} S3 bucket ***".format(
+        "*** COMPLETED: The {} hyperpack was written to the {} S3 bucket ***".format(
             s3_object_key, s3_bucket
         )
     )

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -65,6 +65,7 @@ def write_hyperpack_to_s3(
         s3.meta.client.upload_file(hyperpack_path, s3_bucket_path, "hyperpack.zip")
     except Exception as exp:
         print("exp: ", exp)
+        raise
 
     print("ciao mondo!")
 

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -71,7 +71,11 @@ def write_hyperpack_to_s3(
         print("S3 upload error: ", exp)
         raise
 
-    print("Hyperpack {} written to the {} S3 bucket".format(s3_object_key, s3_bucket))
+    print(
+        "*** COMPLETE: The {} hyperpack was written to the {} S3 bucket ***".format(
+            s3_object_key, s3_bucket
+        )
+    )
 
 
 def write_json(dictionary, json_file_path):

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -29,18 +29,18 @@ def generate_folder_name(
 
 
 def write_hyperpack_to_s3(
-    hyperpack_path="",
+    hyperpack_file="",
     access_key_id=None,
     secret_access_key=None,
     session_token=None,
-    s3_bucket_path=None,
+    s3_bucket=None,
 ):
-    if hyperpack_path == "":
+    if hyperpack_file == "":
         raise ValueError("Please pass in the path to your hyperpack zip file.")
-    elif not os.path.isfile(hyperpack_path):
-        raise FileNotFoundError("No file could be found at {}".format(hyperpack_path))
-    elif not zipfile.is_zipfile(hyperpack_path):
-        raise TypeError("The file {} is an invalid zip file.".format(hyperpack_path))
+    elif not os.path.isfile(hyperpack_file):
+        raise FileNotFoundError("No file could be found at {}".format(hyperpack_file))
+    elif not zipfile.is_zipfile(hyperpack_file):
+        raise TypeError("The file {} is an invalid zip file.".format(hyperpack_file))
 
     if (
         access_key_id in [None, ""]
@@ -51,7 +51,7 @@ def write_hyperpack_to_s3(
             "Please pass in the following AWS S3 credentials: access_key_id, secret_access_key, and session_token."
         )
 
-    if s3_bucket_path in [None, ""]:
+    if s3_bucket in [None, ""]:
         raise ValueError("Please pass in a S3 bucket path.")
 
     s3 = boto3.resource(
@@ -62,7 +62,7 @@ def write_hyperpack_to_s3(
     )
 
     try:
-        s3.meta.client.upload_file(hyperpack_path, s3_bucket_path, "hyperpack.zip")
+        s3.meta.client.upload_file(hyperpack_file, s3_bucket, "hyperpack.zip")
     except Exception as exp:
         print("exp: ", exp)
         raise

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -36,7 +36,7 @@ def write_hyperpack_to_s3(
     s3_bucket=None,
 ):
     if hyperpack_file == "":
-        raise ValueError("Please pass in the path to your hyperpack zip file.")
+        raise ValueError("Please pass in the name or path to your hyperpack zip file.")
     elif not os.path.isfile(hyperpack_file):
         raise FileNotFoundError("No file could be found at {}".format(hyperpack_file))
     elif not zipfile.is_zipfile(hyperpack_file):

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -29,12 +29,20 @@ def generate_folder_name(
 
 
 def write_hyperpack_to_s3(
-    hyperpack_file="",
-    access_key_id=None,
-    secret_access_key=None,
-    session_token=None,
-    s3_bucket=None,
+    hyperpack_file: str = "",
+    access_key_id: str = None,
+    secret_access_key: str = None,
+    session_token: str = None,
+    s3_bucket: str = None,
 ):
+    """Writes hyperpack to a S3 bucket
+    Args:
+        hyperpack_file: name of, or path to, hyperpack file
+        access_key_id: AWS_ACCESS_KEY_ID
+        secret_access_key: AWS_SECRET_ACCESS_KEY
+        session_token: AWS_SESSION_TOKEN
+        s3_bucket: name of S3 bucket
+    """
     if hyperpack_file == "":
         raise ValueError(
             "Please pass in the name of, or path to, your hyperpack zip file."

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -62,7 +62,7 @@ def write_hyperpack_to_s3(
         )
 
     if s3_bucket in [None, ""]:
-        raise ValueError("Please pass in a S3 bucket.")
+        raise ValueError("Please pass in a S3 bucket name.")
 
     s3 = boto3.resource(
         "s3",

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -68,7 +68,7 @@ def write_hyperpack_to_s3(
     try:
         s3.meta.client.upload_file(hyperpack_file, s3_bucket, s3_object_key)
     except Exception as exp:
-        print("Error occurred while uploading the hyperpack: ", exp)
+        print("S3 upload error: ", exp)
         raise
 
     print("Hyperpack {} written to the {} S3 bucket".format(s3_object_key, s3_bucket))

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -61,8 +61,10 @@ def write_hyperpack_to_s3(
         aws_session_token=session_token,
     )
 
+    s3_object_key = hyperpack_file.rsplit("/", 1)[-1]
+
     try:
-        s3.meta.client.upload_file(hyperpack_file, s3_bucket, "hyperpack.zip")
+        s3.meta.client.upload_file(hyperpack_file, s3_bucket, s3_object_key)
     except Exception as exp:
         print("exp: ", exp)
         raise

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -52,7 +52,7 @@ def write_hyperpack_to_s3(
         )
 
     if s3_bucket in [None, ""]:
-        raise ValueError("Please pass in a S3 bucket path.")
+        raise ValueError("Please pass in a S3 bucket.")
 
     s3 = boto3.resource(
         "s3",

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -1,6 +1,7 @@
 import json
 import shutil
 import yaml
+import zipfile
 
 
 def generate_folder_name(
@@ -34,7 +35,8 @@ def write_hyperpack_to_s3(
 ):
     if hyperpack_path == "":
         raise ValueError("Please pass in the path to your hyperpack zip file.")
-
+    elif not zipfile.is_zipfile(hyperpack_path):
+        raise TypeError("Invalid zip file.")
     if (
         access_key_id in [None, ""]
         or secret_access_key in [None, ""]

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -25,6 +25,10 @@ def generate_folder_name(
     return folder_name
 
 
+def write_hyperpack_to_s3():
+    print("ciao mondo!")
+
+
 def write_json(dictionary, json_file_path):
     """Writes object to JSON format
     Args:

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -50,7 +50,7 @@ def write_hyperpack_to_s3(
         or session_token in [None, ""]
     ):
         raise ValueError(
-            "Please pass in the following AWS S3 credentials: access_key_id, secret_access_key, and session_token."
+            "Please pass in all of the following AWS S3 credentials: access_key_id, secret_access_key, and session_token."
         )
 
     if s3_bucket in [None, ""]:

--- a/hyperpackage/hyperpackage/utilities.py
+++ b/hyperpackage/hyperpackage/utilities.py
@@ -1,3 +1,4 @@
+import boto3
 import json
 import os
 import shutil
@@ -52,6 +53,18 @@ def write_hyperpack_to_s3(
 
     if s3_bucket_path in [None, ""]:
         raise ValueError("Please pass in a S3 bucket path.")
+
+    s3 = boto3.resource(
+        "s3",
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key,
+        aws_session_token=session_token,
+    )
+
+    try:
+        s3.meta.client.upload_file(hyperpack_path, s3_bucket_path, "hyperpack.zip")
+    except Exception as exp:
+        print("exp: ", exp)
 
     print("ciao mondo!")
 

--- a/hyperpackage/setup.py
+++ b/hyperpackage/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     include_package_data=True,
-    install_requires=["numpy",],
+    install_requires=["numpy", "boto3"],
     extras_require={"torch": ["pytorch"],},
     packages=setuptools.find_packages(),
     python_requires=">=3.9",


### PR DESCRIPTION
## Summary

_A brief summary of the objective._
Give `hyperpackage` python library user the ability to write a hyperpack to s3.

_Describe your changes._
Added a function called `write_hyperpack_to_s3` that accepts AWS credentials and a s3 bucket name. It writes a hyperpack to a s3 bucket.

## Testing

_Describe steps to follow to verify the changes that were made._
1. Have a valid hyperpack file, e.g., automl.hyperpack.zip.

2. Pip install the `hyperpackage` package with the following command:
`pip install git+https://github.com/gohypergiant/hyperdrive.git@MLSDK-363-write-hyperpack-to-s3#egg=hyperpackage\&subdirectory=hyperpackage`

NOTE: if you're inside a Jupyter Notebook, don't forget the `%` character in front of the `pip`.

3. Import the function from `hyperpackage`:
`from hyperpackage.utilities import write_hyperpack_to_s3`

4. Call the function. If you're in the same directory where the hyperpack is located, the `hyperpack_file` arg can just be the hyperpack name. If you're in a different directory, you'll have to pass the path to the hyperpack. You'll also need the s3 bucket name, as well as your AWS creds (access_key_id, secret_access_key, s3_bucket):
```
write_hyperpack_to_s3(
    hyperpack_file="automl.hyperpack.zip",
    access_key_id="SOME_ACCESS_KEY",
    secret_access_key="SHH_ITS_A_SECRET",
    session_token="ARCADE_QUARTER",
    s3_bucket="KFC_BUCKET"
)
```


_If this ticket is a low-fi ticket specify what if anything is testable. A
"not testable" is perfectly acceptable in this case._
N/A

_Point out any previously tested functionality that may have been changed
and need another look._
N/A

## Notes

_Optional_

_Extra details about the PR that don't fit elsewhere such as dependencies
on another branch, a known issue that needs extra attention, or links._

## Screenshots

_Optional_

## Ticket(s)

- [MLSDK-363](https://gohypergiant.atlassian.net/browse/MLSDK-363)