### PR TITLE
MLSDK-483 Enable support to create hyperpack for univariate timeseries models

### DIFF
--- a/hyperpackage/hyperpackage/flavor/pytorch/__init__.py
+++ b/hyperpackage/hyperpackage/flavor/pytorch/__init__.py
@@ -3,7 +3,7 @@ import torch
 
 
 def torch_onnx_export(
-    model, trial_path: str, train_shape_cols: int,
+    model, trial_path: str, train_shape_cols: int, ml_task : str
 ):
     """Saves pytorch or automl model to ONNX format
     Args:
@@ -11,7 +11,14 @@ def torch_onnx_export(
         trial_path: dir path to the trial
         train_shape_cols: the number of columns in the training dataset used to
                           train the pretrained model
+        ml_task : the type of machine learning task
     """
-    model_path = os.path.join(trial_path, "trained_model")
-    initial_types = torch.randn(1, train_shape_cols)
-    torch.onnx.export(model, initial_types, model_path, train_shape_cols)
+    if ml_task == "univariate_timeseries":
+        for key, m in model.items():
+            model_path = os.path.join(trial_path, "trained_model_" + str(key))
+            initial_types = torch.randn(1, train_shape_cols)
+            torch.onnx.export(m, initial_types, model_path, train_shape_cols)
+    else:
+        model_path = os.path.join(trial_path, "trained_model")
+        initial_types = torch.randn(1, train_shape_cols)
+        torch.onnx.export(model, initial_types, model_path, train_shape_cols)


### PR DESCRIPTION
## Summary

Add support to create hyperpack for univariate timeseries models generated with the [hypergiant automl package](https://github.com/gohypergiant/research-EfficientAutoML)

## Testing

- Download the notebook to generate univariate timeseries models avaiable [here](https://github.com/gohypergiant/research-EfficientAutoML/blob/development/starter_notebooks/univariate_timeseries_starter.ipynb) (this will require to install the automl package and this package)
- Add in one cell the following code and check if it is possible to generate a hyperpack zip file

```python
from hyperpackage.hyperpack_creation import create_hyperpack
create_hyperpack(trained_model=output["model"], model_flavor="automl", ml_task="univariate_timeseries")
```

- Open the zip file and check if there are 8 trained models with names from `trained_model_1` to `trained_model_8` 

## Screenshots


The output of the code block above should look like this:
![image](https://user-images.githubusercontent.com/88676042/193837677-bba34a0f-fc81-4025-aef3-ccad81b3ebb1.png)

The hyperpackage should look like this:
![image](https://user-images.githubusercontent.com/88676042/193837891-01dd59af-ea78-4ae8-b37a-63e7e3bb8158.png)

## Ticket(s)

- [MLSDK-483](https://gohypergiant.atlassian.net/browse/MLSDK-483)